### PR TITLE
[B-241] Remove ctx from constructor and accept queueUrl instead

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @kkowalski @mircobordoni
+* @backend

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 This library implements a SQS consumer.
 
-The library accepts the following parameters in the constructor:
-* `ctx`: the context of the caller
+The constructor accepts the following parameters:
 * `cfg`: an instance of aws sdk v2 configs
-* `queueName`: the SQS queue name
+* `queueURL`: the URL of the SQS queue
 * `visibilityTimeout`: visibility timeout (in seconds) applied to every message pulled from the queue
 * `batchSize`: number of messages retrieved at each SQS poll
 * `workersNum`: size of the workers pool
@@ -21,15 +20,14 @@ func (m *MsgHandler) Run(ctx context.Context, msg *Message) error {
 }
 
 func setupSQSConsumer(){
+    ctx := context.WithCancel(context.Background())
+    queueURL := "https://..."
     visibilityTimeout := 20
     batchSize := 10
     workersNum := 10
-    consumer, err := NewConsumer(ctx, awsCfg, queueName, visibilityTimeout, batchSize, workersNum, MsgHandler{})
-    if err != nil {
-        log.Error("error while creating consumer")
-    }
+    consumer := NewConsumer(awsCfg, queueURL,  queueName, visibilityTimeout, batchSize, workersNum, MsgHandler{})
     
-    go consumer.Consume()
+    go consumer.Consume(ctx)
 }
 ```
 

--- a/pkg/consumer.go
+++ b/pkg/consumer.go
@@ -21,25 +21,18 @@ type Consumer struct {
     wg                *sync.WaitGroup
 }
 
-func NewConsumer(ctx context.Context, cfg aws.Config, queueName string, visibilityTimeout, batchSize, workersNum int, handler Handler) (*Consumer, error) {
-    cons := &Consumer{
+func NewConsumer(cfg aws.Config, queueURL string, visibilityTimeout, batchSize, workersNum int, handler Handler) *Consumer {
+    consumer := &Consumer{
         sqs:               sqs.NewFromConfig(cfg),
         handler:           handler,
+        queueURL:          queueURL,
         workersNum:        workersNum,
         visibilityTimeout: int32(visibilityTimeout),
         batchSize:         int32(batchSize),
         wg:                &sync.WaitGroup{},
     }
 
-    queueUrlOut, err := cons.sqs.GetQueueUrl(ctx, &sqs.GetQueueUrlInput{
-        QueueName: aws.String(queueName),
-    })
-    if err != nil {
-        return nil, err
-    }
-    cons.queueURL = *queueUrlOut.QueueUrl
-
-    return cons, nil
+    return consumer
 }
 
 func (c *Consumer) Consume(ctx context.Context) {

--- a/pkg/consumer_test.go
+++ b/pkg/consumer_test.go
@@ -47,11 +47,7 @@ func TestConsume(t *testing.T) {
     expectedMsg := TestMsg{Name: "TestName"}
 
     msgHandler := handler(t, expectedMsg)
-    consumer, err := NewConsumer(ctx, awsCfg, queueName, visibilityTimeout, batchSize, workersNum, msgHandler)
-    if err != nil {
-        log.Error("error while creating consumer")
-        t.FailNow()
-    }
+    consumer := NewConsumer(awsCfg, *queueUrl, visibilityTimeout, batchSize, workersNum, msgHandler)
     go consumer.Consume(ctx)
 
     t.Cleanup(func() {
@@ -84,13 +80,9 @@ func TestConsume_GracefulShutdown(t *testing.T) {
     awsCfg := loadAWSDefaultConfig(ctx)
 
     queueName := strings.ToLower(t.Name())
-    createQueue(t, ctx, awsCfg, queueName)
+    queueUrl := createQueue(t, ctx, awsCfg, queueName)
 
-    consumer, err := NewConsumer(ctx, awsCfg, queueName, visibilityTimeout, batchSize, workersNum, &MsgHandler{})
-    if err != nil {
-        log.Error("error while creating consumer")
-        t.FailNow()
-    }
+    consumer := NewConsumer(awsCfg, *queueUrl, visibilityTimeout, batchSize, workersNum, &MsgHandler{})
     go func() {
         time.Sleep(time.Second * 1)
         // Cancel context to trigger graceful shutdown


### PR DESCRIPTION
In this PR we:
* remove the context from the Consumer's constructor and just provide the `queueURL` to it
* clean up the readme and tests