### PR TITLE
[B-753] Allow excluding visibility timeout extension

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -47,7 +47,14 @@ func TestConsume(t *testing.T) {
 	expectedMsg := TestMsg{Name: "TestName"}
 
 	msgHandler := handler(t, expectedMsg)
-	consumer := NewConsumer(awsCfg, *queueUrl, visibilityTimeout, batchSize, workersNum, msgHandler)
+	config := Config{
+		QueueURL:          *queueUrl,
+		WorkersNum:        workersNum,
+		VisibilityTimeout: visibilityTimeout,
+		BatchSize:         batchSize,
+		ExtendEnabled:     true,
+	}
+	consumer := NewConsumer(awsCfg, config, msgHandler)
 	go consumer.Consume(ctx)
 
 	t.Cleanup(func() {
@@ -82,7 +89,14 @@ func TestConsume_GracefulShutdown(t *testing.T) {
 	queueName := strings.ToLower(t.Name())
 	queueUrl := createQueue(t, ctx, awsCfg, queueName)
 
-	consumer := NewConsumer(awsCfg, *queueUrl, visibilityTimeout, batchSize, workersNum, &MsgHandler{})
+	config := Config{
+		QueueURL:          *queueUrl,
+		WorkersNum:        workersNum,
+		VisibilityTimeout: visibilityTimeout,
+		BatchSize:         batchSize,
+		ExtendEnabled:     true,
+	}
+	consumer := NewConsumer(awsCfg, config, &MsgHandler{})
 	go func() {
 		time.Sleep(time.Second * 1)
 		// Cancel context to trigger graceful shutdown


### PR DESCRIPTION
The SQS client currently assumes that the visibility timeout of all the messages need to be extended, but that might not be the case for some use case.
In this PR we allow passing a configuration that disables the extension of the visibility timeout.

We also define a struct that contains the configs of the client, instead of passing them in the function that constructs it.