### PR TITLE
B-917 Request Traces message attributes to SQS

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -54,7 +54,7 @@ loop:
 				QueueUrl:              &c.cfg.QueueURL,
 				MaxNumberOfMessages:   c.cfg.BatchSize,
 				WaitTimeSeconds:       int32(5),
-				MessageAttributeNames: []string{"All"},
+				MessageAttributeNames: []string{"TraceID", "SpanID"},
 			})
 			if err != nil {
 				log.WithError(err).Error("could not receive messages from SQS")

--- a/consumer.go
+++ b/consumer.go
@@ -51,9 +51,10 @@ loop:
 			break loop
 		default:
 			output, err := c.sqs.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
-				QueueUrl:            &c.cfg.QueueURL,
-				MaxNumberOfMessages: c.cfg.BatchSize,
-				WaitTimeSeconds:     int32(5),
+				QueueUrl:              &c.cfg.QueueURL,
+				MaxNumberOfMessages:   c.cfg.BatchSize,
+				WaitTimeSeconds:       int32(5),
+				MessageAttributeNames: []string{"All"},
 			})
 			if err != nil {
 				log.WithError(err).Error("could not receive messages from SQS")

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -25,6 +25,8 @@ const (
 	visibilityTimeout = 20
 	batchSize         = 10
 	workersNum        = 1
+	traceId           = "traceid123"
+	spanId            = "spanid123"
 )
 
 type TestMsg struct {
@@ -47,9 +49,13 @@ func TestConsume(t *testing.T) {
 
 	expectedMsg := TestMsg{Name: "TestName"}
 	expectedMsgAttributes := map[string]types.MessageAttributeValue{
-		"key1": {
+		"TraceID": {
 			DataType:    aws.String("String"),
-			StringValue: aws.String("1234"),
+			StringValue: aws.String(traceId),
+		},
+		"SpanID": {
+			DataType:    aws.String("String"),
+			StringValue: aws.String(spanId),
 		},
 	}
 
@@ -164,14 +170,18 @@ func sendTestMsg(t *testing.T, ctx context.Context, consumer *Consumer, queueUrl
 		MessageBody: aws.String(string(messageBodyBytes)),
 		QueueUrl:    queueUrl,
 		MessageAttributes: map[string]types.MessageAttributeValue{
-			"key1": {
+			"TraceID": {
 				DataType:    aws.String("String"),
-				StringValue: aws.String("1234"),
+				StringValue: aws.String(traceId),
+			},
+			"SpanID": {
+				DataType:    aws.String("String"),
+				StringValue: aws.String(spanId),
 			},
 		},
 	})
 	if err != nil {
-		log.Error("error sending message")
+		log.WithError(err).Error("error sending message")
 		t.FailNow()
 	}
 	return expectedMsg


### PR DESCRIPTION
When pulling messages from SQS, the library doesn't specify any message attribute key to pull, so the message then passed to the handler doesn't contain any message attribute. 
With these changes we request the message attributes used to link traces (trace and span ids), so to enable the library users to link traces using this library.