### PR TITLE
[B-1254] fix warnings in CI

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -17,7 +17,7 @@ jobs:
           DEFAULT_REGION: us-east-1
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - run: apk add git gcc musl-dev
       - run: go test ./...
   snyk-scan:
@@ -26,6 +26,6 @@ jobs:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - uses: snyk/actions/setup@master
       - run: snyk test


### PR DESCRIPTION
Our Github pipelines show many warnings, we should fix them.