### PR TITLE
Add consumer with idle trigger

### DIFF
--- a/consumer_with_idle_trigger.go
+++ b/consumer_with_idle_trigger.go
@@ -1,0 +1,137 @@
+package sqsclient
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+
+	"go.uber.org/zap"
+)
+
+type ConsumerWithIdleTrigger struct {
+	sqs                 *sqs.Client
+	handler             HandlerWithIdleTrigger
+	wg                  *sync.WaitGroup
+	cfg                 Config
+	idleDurationTimeout time.Duration
+}
+
+func NewConsumerWithIdleTrigger(awsCfg aws.Config, cfg Config, handler HandlerWithIdleTrigger, idleDurationTimeout time.Duration) *ConsumerWithIdleTrigger {
+	return &ConsumerWithIdleTrigger{
+		sqs:                 sqs.NewFromConfig(awsCfg),
+		handler:             handler,
+		wg:                  &sync.WaitGroup{},
+		cfg:                 cfg,
+		idleDurationTimeout: idleDurationTimeout,
+	}
+}
+
+func (c *ConsumerWithIdleTrigger) Consume(ctx context.Context) {
+	jobs := make(chan *Message)
+	for w := 1; w <= c.cfg.WorkersNum; w++ {
+		go c.worker(ctx, jobs)
+		c.wg.Add(1)
+	}
+	timeout := time.NewTimer(c.idleDurationTimeout)
+	defer timeout.Stop()
+
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			zap.S().Info("closing jobs channel")
+			c.handler.Shutdown()
+			close(jobs)
+			break loop
+		case <-timeout.C:
+			zap.S().Info("No new messages for timeout duration, triggering timeout logic")
+			// a nil message should trigger a timeout
+			jobs <- newMessage(nil)
+			// Reset the timeout
+			timeout.Reset(c.idleDurationTimeout)
+		default:
+			output, err := c.sqs.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+				QueueUrl:              &c.cfg.QueueURL,
+				MaxNumberOfMessages:   c.cfg.BatchSize,
+				WaitTimeSeconds:       int32(c.idleDurationTimeout.Seconds()),
+				MessageAttributeNames: []string{"TraceID", "SpanID"},
+			})
+			if err != nil {
+				zap.S().With(zap.Error(err)).Error("could not receive messages from SQS")
+				continue
+			}
+			if len(output.Messages) > 0 {
+				// Reset the timeout since we received messages
+				if !timeout.Stop() {
+					select {
+					case <-timeout.C:
+					default:
+					}
+				}
+				timeout.Reset(c.idleDurationTimeout)
+			}
+
+			for _, m := range output.Messages {
+				jobs <- newMessage(&m)
+			}
+		}
+	}
+
+	c.wg.Wait()
+}
+
+func (c *ConsumerWithIdleTrigger) worker(ctx context.Context, messages <-chan *Message) {
+	for m := range messages {
+		if err := c.handleMsg(ctx, m); err != nil {
+			zap.S().With(zap.Error(err)).Error("error running handlers")
+		}
+	}
+	zap.S().Info("worker exiting")
+	c.wg.Done()
+}
+
+func (c *ConsumerWithIdleTrigger) handleMsg(ctx context.Context, m *Message) error {
+	if c.handler != nil {
+		if m.Message == nil {
+			if err := c.handler.IdleTimeout(ctx); err != nil {
+				return m.ErrorResponse(err)
+			}
+		} else {
+			if c.cfg.ExtendEnabled {
+				c.extend(ctx, m)
+			}
+			if err := c.handler.Run(ctx, m); err != nil {
+				return m.ErrorResponse(err)
+			}
+			return c.delete(ctx, m) // Message consumed
+		}
+	}
+	m.Success()
+	return nil
+}
+
+func (c *ConsumerWithIdleTrigger) delete(ctx context.Context, m *Message) error {
+	_, err := c.sqs.DeleteMessage(ctx, &sqs.DeleteMessageInput{QueueUrl: &c.cfg.QueueURL, ReceiptHandle: m.ReceiptHandle})
+	if err != nil {
+		zap.S().With(zap.Error(err)).Error("error removing message")
+		return fmt.Errorf("unable to delete message from the queue: %w", err)
+	}
+	zap.S().Debug("message deleted")
+	return nil
+}
+
+func (c *ConsumerWithIdleTrigger) extend(ctx context.Context, m *Message) {
+	_, err := c.sqs.ChangeMessageVisibility(ctx, &sqs.ChangeMessageVisibilityInput{
+		QueueUrl:          &c.cfg.QueueURL,
+		ReceiptHandle:     m.ReceiptHandle,
+		VisibilityTimeout: c.cfg.VisibilityTimeout,
+	})
+	if err != nil {
+		zap.S().With(zap.Error(err)).Error("unable to extend message")
+		return
+	}
+}

--- a/consumer_with_idle_trigger_test.go
+++ b/consumer_with_idle_trigger_test.go
@@ -1,0 +1,207 @@
+package sqsclient
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type MsgHandlerWithIdleTrigger struct {
+	t                     *testing.T
+	msgsReceivedCount     int
+	expectedMsg           TestMsg
+	expectedMsgAttributes interface{}
+	shutdownReceived      bool
+	idleTimeoutTriggered  bool
+}
+
+const (
+	IdleTimeout = 1 * time.Second
+)
+
+func TestConsumeWithIdleTrigger(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	awsCfg := loadAWSDefaultConfig(ctx)
+
+	queueName := strings.ToLower(t.Name())
+	queueUrl := createQueue(t, ctx, awsCfg, queueName)
+
+	expectedMsg := TestMsg{Name: "TestName"}
+	expectedMsgAttributes := map[string]types.MessageAttributeValue{
+		"TraceID": {
+			DataType:    aws.String("String"),
+			StringValue: aws.String(traceId),
+		},
+		"SpanID": {
+			DataType:    aws.String("String"),
+			StringValue: aws.String(spanId),
+		},
+	}
+
+	msgHandler := handlerWithIdleTrigger(t, expectedMsg, expectedMsgAttributes)
+	config := Config{
+		QueueURL:          *queueUrl,
+		WorkersNum:        workersNum,
+		VisibilityTimeout: visibilityTimeout,
+		BatchSize:         batchSize,
+		ExtendEnabled:     true,
+	}
+	consumer := NewConsumerWithIdleTrigger(awsCfg, config, msgHandler, IdleTimeout)
+	go consumer.Consume(ctx)
+
+	t.Cleanup(func() {
+		_, err := consumer.sqs.PurgeQueue(ctx, &sqs.PurgeQueueInput{QueueUrl: queueUrl})
+		if err != nil {
+			zap.S().Error("failed to purge queue")
+			t.FailNow()
+		}
+		cancel()
+	})
+
+	// Send message to the queue
+	sendTestMsg(t, ctx, consumer.sqs, queueUrl, expectedMsg)
+
+	// Wait for the message to arrive
+	time.Sleep(time.Second * 1)
+
+	// Check that the message arrived
+	assert.Equal(t, 1, msgHandler.msgsReceivedCount)
+
+	// Check that received message was deleted from the queue
+	messageCount := getNumOfVisibleMessagesInQueue(t, ctx, consumer.sqs, queueUrl)
+	assert.Equal(t, 0, messageCount)
+	messageCount = getNumOfNotVisibleMessagesInQueue(t, ctx, consumer.sqs, queueUrl)
+	assert.Equal(t, 0, messageCount)
+}
+
+func TestConsumeWithIdleTimeout_GracefulShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	awsCfg := loadAWSDefaultConfig(ctx)
+
+	queueName := strings.ToLower(t.Name())
+	queueUrl := createQueue(t, ctx, awsCfg, queueName)
+
+	config := Config{
+		QueueURL:          *queueUrl,
+		WorkersNum:        workersNum,
+		VisibilityTimeout: visibilityTimeout,
+		BatchSize:         batchSize,
+		ExtendEnabled:     true,
+	}
+	msgHandler := MsgHandlerWithIdleTrigger{
+		t:                 t,
+		msgsReceivedCount: 0,
+	}
+	consumer := NewConsumerWithIdleTrigger(awsCfg, config, &msgHandler, IdleTimeout)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		time.Sleep(time.Second * 1)
+		// Cancel context to trigger graceful shutdown
+		cancel()
+	}()
+	go func() {
+		defer wg.Done()
+		select {
+		case <-time.After(time.Second * 5):
+			zap.S().Error("consumer didn't shut down")
+			t.Fatal("consumer failed to shut down gracefully within the expected time")
+		case <-ctx.Done():
+			zap.S().Info("test context done")
+		}
+	}()
+	// Start consuming messages in a separate goroutine to prevent blocking
+	go func() {
+		consumer.Consume(ctx)
+	}()
+
+	wg.Wait()
+
+	assert.Eventually(t, func() bool {
+		// Check that shutdown was called
+		return msgHandler.shutdownReceived
+	}, time.Second*2, time.Millisecond*100)
+}
+
+func TestConsumeWithIdleTimeout_TimesOut(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	awsCfg := loadAWSDefaultConfig(ctx)
+
+	queueName := strings.ToLower(t.Name())
+	queueUrl := createQueue(t, ctx, awsCfg, queueName)
+
+	config := Config{
+		QueueURL:          *queueUrl,
+		WorkersNum:        workersNum,
+		VisibilityTimeout: visibilityTimeout,
+		BatchSize:         batchSize,
+		ExtendEnabled:     true,
+	}
+	msgHandler := MsgHandlerWithIdleTrigger{
+		t:                 t,
+		msgsReceivedCount: 0,
+	}
+	consumer := NewConsumerWithIdleTrigger(awsCfg, config, &msgHandler, IdleTimeout)
+	go consumer.Consume(ctx)
+
+	t.Cleanup(func() {
+		cancel()
+	})
+
+	// Wait for the timeout
+	time.Sleep(time.Second * 2)
+
+	assert.True(t, msgHandler.idleTimeoutTriggered)
+}
+
+func handlerWithIdleTrigger(t *testing.T, expectedMsg TestMsg, expectedMsgAttributes map[string]types.MessageAttributeValue) *MsgHandlerWithIdleTrigger {
+	return &MsgHandlerWithIdleTrigger{
+		t:                     t,
+		msgsReceivedCount:     0,
+		expectedMsg:           expectedMsg,
+		expectedMsgAttributes: expectedMsgAttributes,
+	}
+}
+
+func (m *MsgHandlerWithIdleTrigger) Run(ctx context.Context, msg *Message) error {
+	zap.S().Info("running message")
+	m.msgsReceivedCount += 1
+	var actualMsg TestMsg
+	err := json.Unmarshal(msg.body(), &actualMsg)
+	if err != nil {
+		zap.S().Error("error unmarshalling message")
+		m.t.FailNow()
+	}
+
+	assert.EqualValues(m.t, m.expectedMsgAttributes, msg.MessageAttributes)
+
+	// Check that the message received is the expected one
+	assert.Equal(m.t, m.expectedMsg, actualMsg)
+
+	return err
+}
+
+func (m *MsgHandlerWithIdleTrigger) Shutdown() {
+	zap.S().Info("Shutting down")
+	m.shutdownReceived = true
+	// Do nothing
+}
+
+func (m *MsgHandlerWithIdleTrigger) IdleTimeout(ctx context.Context) error {
+	zap.S().Info("Idle timeout triggered")
+	m.idleTimeoutTriggered = true
+	return nil
+}

--- a/handler.go
+++ b/handler.go
@@ -6,3 +6,8 @@ type Handler interface {
 	Run(ctx context.Context, msg *Message) error
 	Shutdown()
 }
+
+type HandlerWithIdleTrigger interface {
+	Handler
+	IdleTimeout(ctx context.Context) error
+}


### PR DESCRIPTION
### Notes
* add a consumer with idle trigger. This consumer is identical the other SQS consumer but with an added feature of triggering logic after a certain idle time has been reached.
  * the idle trigger is triggered if no new message has been received.
* This is a feature needed for MPCv2 where it relies on consistent traffic to know when to process requests in batch. If there is a sudden decrease in traffic, some old requests which were waiting to be batched could not be triggered until a new requests arrives. 
Note: We can not add a timeout in MPCv2 since it would require that all nodes timeout at the same time or they could go out of sync
* POC PR can be found here: https://github.com/worldcoin/signup-service/pull/828