### PR TITLE
Add changing visibility timeout for each call

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -27,9 +27,10 @@ type Consumer struct {
 }
 
 func NewConsumer(awsCfg aws.Config, cfg Config, handler Handler) (*Consumer, error) {
-	if cfg.VisibilityTimeoutSeconds <= 0 {
-		return nil, errors.New("VisibilityTimeoutSeconds must be greater than 0")
+	if cfg.VisibilityTimeoutSeconds < 30 {
+		return nil, errors.New("VisibilityTimeoutSeconds must be greater or equal to 30")
 	}
+
 	return &Consumer{
 		sqs:     sqs.NewFromConfig(awsCfg),
 		handler: handler,

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -67,7 +67,6 @@ func TestConsume(t *testing.T) {
 		WorkersNum:        workersNum,
 		VisibilityTimeout: visibilityTimeout,
 		BatchSize:         batchSize,
-		ExtendEnabled:     true,
 	}
 	consumer := NewConsumer(awsCfg, config, msgHandler)
 	go consumer.Consume(ctx)
@@ -109,7 +108,6 @@ func TestConsume_GracefulShutdown(t *testing.T) {
 		WorkersNum:        workersNum,
 		VisibilityTimeout: visibilityTimeout,
 		BatchSize:         batchSize,
-		ExtendEnabled:     true,
 	}
 	msgHandler := MsgHandler{}
 	consumer := NewConsumer(awsCfg, config, &msgHandler)

--- a/consumer_with_idle_trigger.go
+++ b/consumer_with_idle_trigger.go
@@ -23,8 +23,8 @@ type ConsumerWithIdleTrigger struct {
 }
 
 func NewConsumerWithIdleTrigger(awsCfg aws.Config, cfg Config, handler HandlerWithIdleTrigger, idleDurationTimeout time.Duration, sqsReceiveWaitTimeSeconds int32) (*ConsumerWithIdleTrigger, error) {
-	if cfg.VisibilityTimeoutSeconds <= 0 {
-		return nil, errors.New("VisibilityTimeoutSeconds must be greater than 0")
+	if cfg.VisibilityTimeoutSeconds < 30 {
+		return nil, errors.New("VisibilityTimeoutSeconds must be greater or equal to 30")
 	}
 	return &ConsumerWithIdleTrigger{
 		sqs:                       sqs.NewFromConfig(awsCfg),

--- a/consumer_with_idle_trigger.go
+++ b/consumer_with_idle_trigger.go
@@ -103,9 +103,6 @@ func (c *ConsumerWithIdleTrigger) handleMsg(ctx context.Context, m *Message) err
 				return m.ErrorResponse(err)
 			}
 		} else {
-			if c.cfg.ExtendEnabled {
-				c.extend(ctx, m)
-			}
 			if err := c.handler.Run(ctx, m); err != nil {
 				return m.ErrorResponse(err)
 			}

--- a/consumer_with_idle_trigger_test.go
+++ b/consumer_with_idle_trigger_test.go
@@ -57,7 +57,6 @@ func TestConsumeWithIdleTrigger(t *testing.T) {
 		WorkersNum:        workersNum,
 		VisibilityTimeout: visibilityTimeout,
 		BatchSize:         batchSize,
-		ExtendEnabled:     true,
 	}
 	consumer := NewConsumerWithIdleTrigger(awsCfg, config, msgHandler, IdleTimeout, SqsReceiveWaitTimeSeconds)
 	go consumer.Consume(ctx)
@@ -99,7 +98,6 @@ func TestConsumeWithIdleTimeout_GracefulShutdown(t *testing.T) {
 		WorkersNum:        workersNum,
 		VisibilityTimeout: visibilityTimeout,
 		BatchSize:         batchSize,
-		ExtendEnabled:     true,
 	}
 	msgHandler := MsgHandlerWithIdleTrigger{
 		t:                 t,
@@ -150,7 +148,6 @@ func TestConsumeWithIdleTimeout_TimesOut(t *testing.T) {
 		WorkersNum:        workersNum,
 		VisibilityTimeout: visibilityTimeout,
 		BatchSize:         batchSize,
-		ExtendEnabled:     true,
 	}
 	msgHandler := MsgHandlerWithIdleTrigger{
 		t:                 t,
@@ -193,7 +190,6 @@ func TestConsumeWithIdleTimeout_TimesOutAndConsumes(t *testing.T) {
 		WorkersNum:        workersNum,
 		VisibilityTimeout: visibilityTimeout,
 		BatchSize:         batchSize,
-		ExtendEnabled:     true,
 	}
 	msgHandler := handlerWithIdleTrigger(t, expectedMsg, expectedMsgAttributes)
 	consumer := NewConsumerWithIdleTrigger(awsCfg, config, msgHandler, IdleTimeout, SqsReceiveWaitTimeSeconds)

--- a/consumer_with_idle_trigger_test.go
+++ b/consumer_with_idle_trigger_test.go
@@ -53,12 +53,13 @@ func TestConsumeWithIdleTrigger(t *testing.T) {
 
 	msgHandler := handlerWithIdleTrigger(t, expectedMsg, expectedMsgAttributes)
 	config := Config{
-		QueueURL:          *queueUrl,
-		WorkersNum:        workersNum,
-		VisibilityTimeout: visibilityTimeout,
-		BatchSize:         batchSize,
+		QueueURL:                 *queueUrl,
+		WorkersNum:               workersNum,
+		VisibilityTimeoutSeconds: visibilityTimeout,
+		BatchSize:                batchSize,
 	}
-	consumer := NewConsumerWithIdleTrigger(awsCfg, config, msgHandler, IdleTimeout, SqsReceiveWaitTimeSeconds)
+	consumer, err := NewConsumerWithIdleTrigger(awsCfg, config, msgHandler, IdleTimeout, SqsReceiveWaitTimeSeconds)
+	assert.NoError(t, err)
 	go consumer.Consume(ctx)
 
 	t.Cleanup(func() {
@@ -94,16 +95,17 @@ func TestConsumeWithIdleTimeout_GracefulShutdown(t *testing.T) {
 	queueUrl := createQueue(t, ctx, awsCfg, queueName)
 
 	config := Config{
-		QueueURL:          *queueUrl,
-		WorkersNum:        workersNum,
-		VisibilityTimeout: visibilityTimeout,
-		BatchSize:         batchSize,
+		QueueURL:                 *queueUrl,
+		WorkersNum:               workersNum,
+		VisibilityTimeoutSeconds: visibilityTimeout,
+		BatchSize:                batchSize,
 	}
 	msgHandler := MsgHandlerWithIdleTrigger{
 		t:                 t,
 		msgsReceivedCount: 0,
 	}
-	consumer := NewConsumerWithIdleTrigger(awsCfg, config, &msgHandler, IdleTimeout, SqsReceiveWaitTimeSeconds)
+	consumer, err := NewConsumerWithIdleTrigger(awsCfg, config, &msgHandler, IdleTimeout, SqsReceiveWaitTimeSeconds)
+	assert.NoError(t, err)
 	var wg sync.WaitGroup
 	wg.Add(2)
 
@@ -144,16 +146,17 @@ func TestConsumeWithIdleTimeout_TimesOut(t *testing.T) {
 	queueUrl := createQueue(t, ctx, awsCfg, queueName)
 
 	config := Config{
-		QueueURL:          *queueUrl,
-		WorkersNum:        workersNum,
-		VisibilityTimeout: visibilityTimeout,
-		BatchSize:         batchSize,
+		QueueURL:                 *queueUrl,
+		WorkersNum:               workersNum,
+		VisibilityTimeoutSeconds: visibilityTimeout,
+		BatchSize:                batchSize,
 	}
 	msgHandler := MsgHandlerWithIdleTrigger{
 		t:                 t,
 		msgsReceivedCount: 0,
 	}
-	consumer := NewConsumerWithIdleTrigger(awsCfg, config, &msgHandler, IdleTimeout, SqsReceiveWaitTimeSeconds)
+	consumer, err := NewConsumerWithIdleTrigger(awsCfg, config, &msgHandler, IdleTimeout, SqsReceiveWaitTimeSeconds)
+	assert.NoError(t, err)
 	go consumer.Consume(ctx)
 
 	t.Cleanup(func() {
@@ -165,6 +168,28 @@ func TestConsumeWithIdleTimeout_TimesOut(t *testing.T) {
 
 	// ensure that it gets called multiple times
 	assert.GreaterOrEqual(t, msgHandler.idleTimeoutTriggeredCount, 2)
+}
+
+func TestConsumeWithIdleTimeout_ErrorsIfConfigIssues(t *testing.T) {
+	ctx, _ := context.WithTimeout(context.Background(), time.Second*10)
+	awsCfg := loadAWSDefaultConfig(ctx)
+
+	queueName := strings.ToLower(t.Name())
+	queueUrl := createQueue(t, ctx, awsCfg, queueName)
+
+	config := Config{
+		QueueURL:                 *queueUrl,
+		WorkersNum:               workersNum,
+		VisibilityTimeoutSeconds: 0,
+		BatchSize:                batchSize,
+	}
+	msgHandler := MsgHandlerWithIdleTrigger{
+		t:                 t,
+		msgsReceivedCount: 0,
+	}
+	consumer, err := NewConsumerWithIdleTrigger(awsCfg, config, &msgHandler, IdleTimeout, SqsReceiveWaitTimeSeconds)
+	assert.Error(t, err)
+	assert.Nil(t, consumer)
 }
 func TestConsumeWithIdleTimeout_TimesOutAndConsumes(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
@@ -186,13 +211,14 @@ func TestConsumeWithIdleTimeout_TimesOutAndConsumes(t *testing.T) {
 	}
 
 	config := Config{
-		QueueURL:          *queueUrl,
-		WorkersNum:        workersNum,
-		VisibilityTimeout: visibilityTimeout,
-		BatchSize:         batchSize,
+		QueueURL:                 *queueUrl,
+		WorkersNum:               workersNum,
+		VisibilityTimeoutSeconds: visibilityTimeout,
+		BatchSize:                batchSize,
 	}
 	msgHandler := handlerWithIdleTrigger(t, expectedMsg, expectedMsgAttributes)
-	consumer := NewConsumerWithIdleTrigger(awsCfg, config, msgHandler, IdleTimeout, SqsReceiveWaitTimeSeconds)
+	consumer, err := NewConsumerWithIdleTrigger(awsCfg, config, msgHandler, IdleTimeout, SqsReceiveWaitTimeSeconds)
+	assert.NoError(t, err)
 	go consumer.Consume(ctx)
 
 	t.Cleanup(func() {


### PR DESCRIPTION
### Notes
* deprecate extend enabled and update the visibility timeout for each receive instead
* this saves SQS calls on each worker