### PR TITLE
pin gh actions to shas

### DIFF
--- a/.github/workflows/relyance-sci.yml
+++ b/.github/workflows/relyance-sci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Pull and run SCI binary
         run: |-

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -20,12 +20,3 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: apk add git gcc musl-dev
       - run: go test ./...
-  snyk-scan:
-    runs-on: ubuntu-latest
-    env:
-      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: snyk/actions/setup@master
-      - run: snyk test

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -17,7 +17,7 @@ jobs:
           DEFAULT_REGION: us-east-1
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: apk add git gcc musl-dev
       - run: go test ./...
   snyk-scan:
@@ -26,6 +26,6 @@ jobs:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: snyk/actions/setup@master
       - run: snyk test


### PR DESCRIPTION
## Change
- Remove tags from GH actions and point into specific commit SHAs as recent experience showed that repos could be hacked and tags could be updated