### PR TITLE
Add using a local copy for job messages

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
-
 	"go.uber.org/zap"
 )
 
@@ -72,8 +71,9 @@ loop:
 				continue
 			}
 
-			for _, m := range output.Messages {
-				jobs <- newMessage(&m)
+			for _, msg := range output.Messages {
+				localMsg := msg // Create a local copy to avoid reference issues
+				jobs <- newMessage(&localMsg)
 			}
 		}
 	}


### PR DESCRIPTION
### Notes
* we are seeing duplicate messages being processed by the worker. This is due to the message being overwritten in the loop (time is too short for it to be fifo related) ie: https://app.datadoghq.com/logs?query=env%3Aprod%20service%3Asignup-service-worker%20%40capture_id%3A001228a7ff1c494b513a175300000000&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1745962367774&to_ts=1745962415773&live=false
* This should fix this and also potentially stop the latency we are seeing