### PR TITLE
chore(POP-364): Fix localstack free version

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       localstack:
-        image: localstack/localstack:latest
+        image: public.ecr.aws/localstack/localstack:4.14
         env:
           SERVICES: sqs
           DEFAULT_REGION: us-east-1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.1"
 
 services:
   localstack:
-    image: localstack/localstack
+    image: public.ecr.aws/localstack/localstack:4.14
     ports:
       - "127.0.0.1:4566:4566"
     environment:


### PR DESCRIPTION
Due to changes in the licensing schema, we are going to pin the version of the Localstack. 